### PR TITLE
fix datetime return nil without Locale and Timezone

### DIFF
--- a/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
+++ b/Sources/SwifterSwift/SwiftStdlib/StringExtensions.swift
@@ -327,7 +327,8 @@ public extension String {
     var date: Date? {
         let selfLowercased = trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let formatter = DateFormatter()
-        formatter.timeZone = TimeZone.current
+        formatter.locale = .init(identifier: Locale.current.identifier)
+        formatter.timeZone = .init(identifier: Locale.current.identifier)
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.date(from: selfLowercased)
     }
@@ -341,7 +342,8 @@ public extension String {
     var dateTime: Date? {
         let selfLowercased = trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let formatter = DateFormatter()
-        formatter.timeZone = TimeZone.current
+        formatter.locale = .init(identifier: Locale.current.identifier)
+        formatter.timeZone = .init(identifier: Locale.current.identifier)
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         return formatter.date(from: selfLowercased)
     }
@@ -966,9 +968,12 @@ public extension String {
     /// - Parameter format: date format.
     /// - Returns: Date object from string (if applicable).
     func date(withFormat format: String) -> Date? {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = format
-        return dateFormatter.date(from: self)
+        let selfLowercased = trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let formatter = DateFormatter()
+        formatter.locale = .init(identifier: Locale.current.identifier)
+        formatter.timeZone = .init(identifier: Locale.current.identifier)
+        formatter.dateFormat = format
+        return formatter.date(from: selfLowercased)
     }
     #endif
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] New extensions are written in Swift 5.6.
- [ ] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [ ] I have added tests for new extensions, and they passed.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
